### PR TITLE
Refactor SSD read/write

### DIFF
--- a/virtual_ssd/ssd.py
+++ b/virtual_ssd/ssd.py
@@ -21,14 +21,21 @@ class SSD:
         with open(SSD.DATA_LOC, "wb") as handle:
             pickle.dump(initial_data, handle)
 
+    def __read_nand(self) -> dict:
+        with open(SSD.DATA_LOC, "rb") as read_handle:
+            result = pickle.loads(read_handle.read())
+
+        return result
+
+    def __init_result_file(self):
+        return open(SSD.DATA_READ, 'w')
+
     def read(self, addr):
         try:
-            with open(SSD.DATA_LOC, "rb") as handle:
-                read_data = pickle.load(handle)
-
-            with open(SSD.DATA_READ, 'w') as result_file:
-                result_file.write(read_data[addr])
-                result_file.close()
+            read_data = self.__read_nand()
+            result_file = self.__init_result_file()
+            result_file.write(read_data[addr])
+            result_file.close()
 
             return SSD.READ_SUCCESS
         except:
@@ -36,10 +43,7 @@ class SSD:
                 os.remove(SSD.DATA_READ)
 
     def write(self, addr, value):
-        dump = {}
-
-        with open(SSD.DATA_LOC, "rb") as read_handle:
-            dump = pickle.loads(read_handle.read())
+        dump = self.__read_nand()
 
         dump[addr] = value
 

--- a/virtual_ssd/test_ssd.py
+++ b/virtual_ssd/test_ssd.py
@@ -10,7 +10,7 @@ class TestSSD(TestCase):
     @patch.object(SSD, "read")
     def test_read_mock(self, mk):
         def read(addr):
-            if addr < 0 or 99 < addr:
+            if not 0 < addr < SSD.MAX_ADDR:
                 raise TypeError
             return 0x88888888
 


### PR DESCRIPTION
- read/write에서 nand를 읽는 부분이 동일하여 __read_nand method로 추출
- SSD.MAX SIZE 를 SSD.MAX_ADDR 사용