### PR TITLE
Feature/shell read

### DIFF
--- a/test_shell_app/shell.py
+++ b/test_shell_app/shell.py
@@ -20,7 +20,7 @@ class Shell:
 
         try:
             _, stderr = Popen(
-                f"python ../virtual_ssd/ssd.py W {addr} {val}",
+                f"python ../virtual_ssd/ssd.py ssd W {addr} {val}",
                 shell=True,
                 stdout=PIPE,
                 stderr=PIPE,
@@ -39,7 +39,7 @@ class Shell:
 
         try:
             _, stderr = Popen(
-                f"python ../virtual_ssd/ssd.py R {addr}",
+                f"python ../virtual_ssd/ssd.py ssd R {addr}",
                 shell=True,
                 stdout=PIPE,
                 stderr=PIPE,

--- a/test_shell_app/shell.py
+++ b/test_shell_app/shell.py
@@ -1,5 +1,5 @@
-from subprocess import PIPE, Popen
 import re
+from subprocess import PIPE, Popen
 
 INVALID_PARAMETER = "INVALID PARAMETER"
 
@@ -11,43 +11,48 @@ class Shell:
     def write(self, addr, val):
         if addr < 0 or addr > 99:
             print(INVALID_PARAMETER, flush=True)
-            return ""
+            return None
 
         pattern = r"^0x[A-F0-9]+$"
         if not re.match(pattern, val):
             print(INVALID_PARAMETER, flush=True)
-            return ""
+            return None
 
         try:
             _, stderr = Popen(
-                f"ssd W {addr} {val}", shell=True, stdout=PIPE, stderr=PIPE
+                f"python ../virtual_ssd/ssd.py W {addr} {val}",
+                shell=True,
+                stdout=PIPE,
+                stderr=PIPE,
             ).communicate()
             if stderr != "":
-                raise Exception("stderr")
+                raise Exception(stderr.decode("cp949"))
 
         except Exception as e:
-            print(f"EXCEPTION OCCUR {e}")
-            return ""
+            print(f"EXCEPTION OCCUR : {e}")
+            return None
 
     def read(self, addr):
         if addr < 0 or addr > 99:
             print("INVALID PARAMETER", flush=True)
-            return ""
+            return None
 
         try:
             _, stderr = Popen(
-                f"ssd R {addr}", shell=True, stdout=PIPE, stderr=PIPE
+                f"python ../virtual_ssd/ssd.py R {addr}",
+                shell=True,
+                stdout=PIPE,
+                stderr=PIPE,
             ).communicate()
-
             if stderr != "":
                 raise Exception(stderr.decode("cp949"))
             with open("../result.txt") as file_data:
                 val = file_data.readline()
-                print(val, end="")
+                print(val)
             return val
         except Exception as e:
             print(f"EXCEPTION OCCUR : {e}")
-            return ""
+            return None
 
     def exit(self):
         pass

--- a/test_shell_app/test_shell.py
+++ b/test_shell_app/test_shell.py
@@ -43,7 +43,7 @@ class TestShell(TestCase):
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_write_invalid_input_addr(self, mock_stdout):
         self.assertIsNone(self.shell.write(INVALID_TEST_ADDR, TEST_VAL))
-        self.assertEqual(mock_stdout.getvalue(), "INVALID PARAMETER\n")
+        self.assertEqual(mock_stdout.getvalue(), INVALID_PARAMETER_TEXT)
 
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_write_invalid_input_val(self, mock_stdout):

--- a/test_shell_app/test_shell.py
+++ b/test_shell_app/test_shell.py
@@ -32,22 +32,22 @@ class TestShell(TestCase):
 
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_read_invalid_input_pos(self, mock_stdout):
-        self.assertEqual("", self.shell.read(LARGE_ADDR))
+        self.assertIsNone(self.shell.read(LARGE_ADDR))
         self.assertEqual(mock_stdout.getvalue(), "%s" % INVALID_PARAMETER_TEXT)
 
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_read_invalid_input_neg(self, mock_stdout):
-        self.assertEqual("", self.shell.read(NEG_ADDR))
+        self.assertIsNone(self.shell.read(NEG_ADDR))
         self.assertEqual(mock_stdout.getvalue(), INVALID_PARAMETER_TEXT)
 
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_write_invalid_input_addr(self, mock_stdout):
-        self.assertEqual("", self.shell.write(NEG_ADDR, TEST_VAL))
+        self.assertIsNone(self.shell.write(NEG_ADDR, TEST_VAL))
         self.assertEqual(mock_stdout.getvalue(), "INVALID PARAMETER\n")
 
     @patch("sys.stdout", new_callable=io.StringIO)
     def test_write_invalid_input_val(self, mock_stdout):
-        self.assertEqual("", self.shell.write(TEST_ADDR, INVALID_TEST_VAL))
+        self.assertIsNone(self.shell.write(TEST_ADDR, INVALID_TEST_VAL))
         self.assertEqual(mock_stdout.getvalue(), "INVALID PARAMETER\n")
 
     @patch.object(Shell, "write")


### PR DESCRIPTION
- invalid return type none으로 변경
- system command encode cp949 적용
- shell에서 ssd.py 실행 상대경로 적용