### PR TITLE
[hotfix] Popen의 binary string 리턴 대응

### DIFF
--- a/test_shell_app/shell.py
+++ b/test_shell_app/shell.py
@@ -25,7 +25,7 @@ class Shell:
                 stdout=PIPE,
                 stderr=PIPE,
             ).communicate()
-            if stderr != "":
+            if stderr != b"":
                 raise Exception(stderr.decode("cp949"))
 
         except Exception as e:
@@ -44,7 +44,7 @@ class Shell:
                 stdout=PIPE,
                 stderr=PIPE,
             ).communicate()
-            if stderr != "":
+            if stderr != b"":
                 raise Exception(stderr.decode("cp949"))
             with open("../result.txt") as file_data:
                 val = file_data.readline()


### PR DESCRIPTION
Popen이 binary string을 리턴하는데, 이로 인해 조건문이 의도한 대로 동작하지 않아 수정하였습니다.