### PR TITLE
Feature/enable to specify ssd nand

### DIFF
--- a/virtual_ssd/ssd.py
+++ b/virtual_ssd/ssd.py
@@ -11,8 +11,12 @@ class SSD:
     SUCCESS = "SUCCESS"
     FAIL = "FAIL"
 
-    def __init__(self):
-        if not os.path.exists(SSD.DATA_LOC):
+    def __init__(self, nand_filename: str = None, result_filename: str = None):
+
+        self.__nand_filename = nand_filename if nand_filename else SSD.DATA_LOC
+        self.__result_filename = result_filename if result_filename else SSD.DATA_READ
+
+        if not os.path.exists(self.__nand_filename):
             self.init_nand()
 
     def init_nand(self):
@@ -20,17 +24,17 @@ class SSD:
         for i in range(SSD.MAX_ADDR):
             initial_data[i] = SSD.INIT_DATA
 
-        with open(SSD.DATA_LOC, "wb") as handle:
+        with open(self.__nand_filename, "wb") as handle:
             pickle.dump(initial_data, handle)
 
     def __read_nand(self) -> dict:
-        with open(SSD.DATA_LOC, "rb") as read_handle:
+        with open(self.__nand_filename, "rb") as read_handle:
             result = pickle.loads(read_handle.read())
 
         return result
 
     def __write_result_file(self, data: str):
-        with open(SSD.DATA_READ, "w") as result_handle:
+        with open(self.__result_filename, "w") as result_handle:
             result_handle.write(data)
 
     def read(self, addr: int):
@@ -40,8 +44,8 @@ class SSD:
 
             return SSD.SUCCESS
         except:
-            if os.path.isfile(SSD.DATA_READ):
-                os.remove(SSD.DATA_READ)
+            if os.path.isfile(self.__result_filename):
+                os.remove(self.__result_filename)
 
             return SSD.FAIL
 
@@ -54,7 +58,7 @@ class SSD:
 
         dump[addr] = value
 
-        with open(SSD.DATA_LOC, "wb") as write_handle:
+        with open(self.__nand_filename, "wb") as write_handle:
             pickle.dump(dump, write_handle)
 
         return SSD.SUCCESS

--- a/virtual_ssd/test_ssd.py
+++ b/virtual_ssd/test_ssd.py
@@ -1,3 +1,5 @@
+import time
+import os
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -6,7 +8,19 @@ from ssd import SSD
 
 class TestSSD(TestCase):
     def setUp(self):
-        self.ssd = SSD()
+        current_time = int(time.time())
+
+        self.__test_nand_filename = f"test_nand_{current_time}"
+        self.__test_result_filename = f"test_nand_{current_time}"
+
+        self.ssd = SSD(self.__test_nand_filename, self.__test_result_filename)
+
+    def tearDown(self):
+        if os.path.exists(self.__test_nand_filename):
+            os.remove(self.__test_nand_filename)
+
+        if os.path.exists(self.__test_result_filename):
+            os.remove(self.__test_result_filename)
 
     @patch.object(SSD, "read")
     def test_read_mock(self, mk):
@@ -23,6 +37,8 @@ class TestSSD(TestCase):
     def test_read_real(self):
         try:
             self.assertEqual(self.ssd.read(1), SSD.SUCCESS)
+            with open(self.__test_result_filename, "r") as f:
+                self.assertEqual(f.read(), SSD.INIT_DATA)
         except:
             self.fail()
 
@@ -34,7 +50,7 @@ class TestSSD(TestCase):
 
         self.assertEqual(ret, SSD.SUCCESS)
         self.assertEqual(self.ssd.read(addr), SSD.SUCCESS)
-        with open(SSD.DATA_READ, "r") as f:
+        with open(self.__test_result_filename, "r") as f:
             self.assertEqual(f.read(), value)
 
     def test_write_invalid_value(self):


### PR DESCRIPTION
SSD init 시 nand.txt와 result.txt 역할의 경로를 입력 받도록 수정하여 test 등 실제 동작 이외의 행동에 의한 데이터 훼손을 방지했습니다.