### PR TITLE
refactor: change test import

### DIFF
--- a/test_shell_app/test/test_runner.py
+++ b/test_shell_app/test/test_runner.py
@@ -1,12 +1,13 @@
 import io
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from unittest import TestCase
 from unittest.mock import patch
 
-from test_shell_app.Scripts.runner import Runner
+from Scripts.runner import Runner
 
 
 class TestRunner(TestCase):

--- a/test_shell_app/test/test_script.py
+++ b/test_shell_app/test/test_script.py
@@ -1,11 +1,12 @@
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from unittest import TestCase
 
-from test_shell_app.Scripts.testapp1 import TestApp1
-from test_shell_app.Scripts.testapp2 import TestApp2
+from Scripts.testapp1 import TestApp1
+from Scripts.testapp2 import TestApp2
 
 TEST_VALUE = "0x12345678"
 

--- a/test_shell_app/test/test_shell.py
+++ b/test_shell_app/test/test_shell.py
@@ -1,13 +1,14 @@
 import io
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from unittest import TestCase
 from unittest.mock import patch
 
-from test_shell_app.shell import Shell
-from test_shell_app.Utils.message_manager import InvalidArgumentMessageManager
+from shell import Shell
+from Utils.message_manager import InvalidArgumentMessageManager
 
 INVALID_PARAMETER_TEXT = InvalidArgumentMessageManager().message
 EXCEPTION_OCCUR_TEXT = "EXCEPTION OCCUR"

--- a/test_shell_app/test/test_shell_main.py
+++ b/test_shell_app/test/test_shell_main.py
@@ -1,13 +1,14 @@
 import io
-import sys, os
+import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from test_shell_app.shell_main import ShellMain
-from test_shell_app.Utils.message_manager import *
+from shell_main import ShellMain
+from Utils.message_manager import *
 
 INVALID_COMMAND = "NO_COMMAND"
 EXIT_COMMAND = "exit"


### PR DESCRIPTION
Test code 관련 import 수정하였습니다.
- `sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))` code가 상위 test_shell_app 경로를 포함하므로 prefix로 test_shell_app 불필요